### PR TITLE
1. SubCommentController

### DIFF
--- a/src/main/java/com/example/intermediate/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/example/intermediate/configuration/SecurityConfiguration.java
@@ -58,6 +58,7 @@ public class SecurityConfiguration {
         .antMatchers("/api/member/**").permitAll()
         .antMatchers("/api/post/**").permitAll()
         .antMatchers("/api/comment/**").permitAll()
+        .antMatchers("/api/sub-comment/**").permitAll()
         .anyRequest().authenticated()
 
         .and()

--- a/src/main/java/com/example/intermediate/controller/LikeController.java
+++ b/src/main/java/com/example/intermediate/controller/LikeController.java
@@ -14,24 +14,34 @@ public class LikeController {
 
     private final LikeService likeService;
 
-    @PostMapping("/post/like/{postId}")
+    @PostMapping("/like/post/{postId}")
     public ResponseDto<?> likeByPostId(@PathVariable Long postId, HttpServletRequest request) {
         return likeService.likeByPostid(postId, request);
     }
 
-    @DeleteMapping("/post/like/{postId}")
+    @DeleteMapping("/like/post/{postId}")
     public ResponseDto<?> unLikeByPostId(@PathVariable Long postId, HttpServletRequest request) {
         return likeService.unLikeByPostId(postId, request);
     }
 
-    @PostMapping("/comment/like/{commentId}")
+    @PostMapping("/like/comment/{commentId}")
     public ResponseDto<?> likeByCommentId(@PathVariable Long commentId, HttpServletRequest request) {
         return likeService.likeByCommentId(commentId, request);
     }
 
-    @DeleteMapping("/comment/like/{commentId}")
+    @DeleteMapping("/like/comment/{commentId}")
     public ResponseDto<?> unLikeByCommentId(@PathVariable Long commentId, HttpServletRequest request) {
         return likeService.unLikeByCommentId(commentId, request);
+    }
+
+    @PostMapping("/like/subcomment/{subCommentId}")
+    public ResponseDto<?> likeBySubCommentId(@PathVariable Long subCommentId, HttpServletRequest request) {
+        return likeService.likeBySubCommentId(subCommentId, request);
+    }
+
+    @DeleteMapping("/like/subcomment/{subCommentId}")
+    public ResponseDto<?> unLikeBySubCommentId(@PathVariable Long subCommentId, HttpServletRequest request) {
+        return likeService.unLikeBySubCommentId(subCommentId, request);
     }
 
 }

--- a/src/main/java/com/example/intermediate/controller/SubCommentController.java
+++ b/src/main/java/com/example/intermediate/controller/SubCommentController.java
@@ -14,29 +14,29 @@ import javax.servlet.http.HttpServletRequest;
 @RestController
 public class SubCommentController {
 
-    private final SubCommentService subcommentService;
+    private final SubCommentService subCommentService;
 
 
-    @RequestMapping(value = "/api/auth/subcomment", method = RequestMethod.POST)
-    public ResponseDto<?> createComment(@RequestBody SubCommentRequestDto requestDto,
+    @RequestMapping(value = "/api/auth/sub-comment", method = RequestMethod.POST)
+    public ResponseDto<?> createSubComment(@RequestBody SubCommentRequestDto requestDto,
                                         HttpServletRequest request) {
-        return subcommentService.createSubComment(requestDto, request);
+        return subCommentService.createSubComment(requestDto, request);
     }
 
-    @RequestMapping(value = "/api/subcomment/{id}", method = RequestMethod.GET)
-    public ResponseDto<?> getAllComments(@PathVariable Long id) {
-        return subcommentService.getAllSubCommentsByComment(id);
+    @RequestMapping(value = "/api/sub-comment/{id}", method = RequestMethod.GET)
+    public ResponseDto<?> getAllSubComments(@PathVariable Long id) {
+        return subCommentService.getAllSubCommentsByComment(id);
     }
 
-    @RequestMapping(value = "/api/auth/subcomment/{id}", method = RequestMethod.PUT)
-    public ResponseDto<?> updateComment(@PathVariable Long id, @RequestBody SubCommentRequestDto requestDto,
+    @RequestMapping(value = "/api/auth/sub-comment/{id}", method = RequestMethod.PUT)
+    public ResponseDto<?> updateSubComment(@PathVariable Long id, @RequestBody SubCommentRequestDto requestDto,
                                         HttpServletRequest request) {
-        return subcommentService.updateSubComment(id, requestDto, request);
+        return subCommentService.updateSubComment(id, requestDto, request);
     }
 
-    @RequestMapping(value = "/api/auth/subcomment/{id}", method = RequestMethod.DELETE)
-    public ResponseDto<?> deleteComment(@PathVariable Long id,
+    @RequestMapping(value = "/api/auth/sub-comment/{id}", method = RequestMethod.DELETE)
+    public ResponseDto<?> deleteSubComment(@PathVariable Long id,
                                         HttpServletRequest request) {
-        return subcommentService.deleteSubComment(id, request);
+        return subCommentService.deleteSubComment(id, request);
     }
 }

--- a/src/main/java/com/example/intermediate/domain/Comment.java
+++ b/src/main/java/com/example/intermediate/domain/Comment.java
@@ -34,7 +34,7 @@ public class Comment extends Timestamped {
   private String content;
 
   /* 220809 hyuk 추가 */
-  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Like> likes;
 
   public void update(CommentRequestDto commentRequestDto) {

--- a/src/main/java/com/example/intermediate/domain/Like.java
+++ b/src/main/java/com/example/intermediate/domain/Like.java
@@ -31,6 +31,10 @@ public class Like extends Timestamped {
     @ManyToOne(fetch = FetchType.LAZY)
     private Comment comment;
 
+    @JoinColumn(name = "subcomment_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private SubComment subComment;
+
     public boolean validateMember(Member member) {
         return !this.member.equals(member);
     }

--- a/src/main/java/com/example/intermediate/domain/Post.java
+++ b/src/main/java/com/example/intermediate/domain/Post.java
@@ -45,7 +45,7 @@ public class Post extends Timestamped {
   private Member member;
 
   /* 220809 hyuk 추가 */
-  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Like> likes;
 
   public void update(PostRequestDto postRequestDto) {

--- a/src/main/java/com/example/intermediate/domain/SubComment.java
+++ b/src/main/java/com/example/intermediate/domain/SubComment.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Builder
 @Getter
@@ -29,6 +30,10 @@ public class SubComment extends Timestamped {
 
     @Column(nullable = false)
     private String content;
+
+    /* 220809 hyuk 추가 */
+    @OneToMany(mappedBy = "subComment", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Like> likes;
 
     public void update(SubCommentRequestDto subcommentRequestDto) {
         this.content = subcommentRequestDto.getContent();

--- a/src/main/java/com/example/intermediate/repository/LikeRepository.java
+++ b/src/main/java/com/example/intermediate/repository/LikeRepository.java
@@ -3,5 +3,10 @@ package com.example.intermediate.repository;
 import com.example.intermediate.domain.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByPostId(Long postId);
+    Optional<Like> findByCommentId(Long commentId);
+    Optional<Like> findBySubCommentId(Long subCommentId);
 }

--- a/src/main/java/com/example/intermediate/service/LikeService.java
+++ b/src/main/java/com/example/intermediate/service/LikeService.java
@@ -1,9 +1,6 @@
 package com.example.intermediate.service;
 
-import com.example.intermediate.domain.Comment;
-import com.example.intermediate.domain.Like;
-import com.example.intermediate.domain.Member;
-import com.example.intermediate.domain.Post;
+import com.example.intermediate.domain.*;
 import com.example.intermediate.dto.response.ResponseDto;
 import com.example.intermediate.jwt.TokenProvider;
 import com.example.intermediate.repository.LikeRepository;
@@ -21,6 +18,7 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final PostService postService;
     private final CommentService commentService;
+    private final SubCommentService subCommentService;
     private final TokenProvider tokenProvider;
 
     @Transactional
@@ -54,6 +52,43 @@ public class LikeService {
     }
 
     @Transactional
+    public ResponseDto<?> unLikeByPostId(Long postId, HttpServletRequest request) {
+
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Post post = postService.isPresentPost(postId);
+        if (null == post) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+        Like like = isPresentLikeByPostId(postId);
+        if (null == like) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 좋아요 id 입니다.");
+        }
+
+        if (like.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+
+        likeRepository.delete(like);
+
+        return ResponseDto.success("Unlike success");
+    }
+
+    @Transactional
     public ResponseDto<?> likeByCommentId(Long commentId, HttpServletRequest request) {
         if (null == request.getHeader("Refresh-Token")) {
             return ResponseDto.fail("MEMBER_NOT_FOUND",
@@ -84,43 +119,6 @@ public class LikeService {
     }
 
     @Transactional
-    public ResponseDto<?> unLikeByPostId(Long postId, HttpServletRequest request) {
-
-        if (null == request.getHeader("Refresh-Token")) {
-            return ResponseDto.fail("MEMBER_NOT_FOUND",
-                    "로그인이 필요합니다.");
-        }
-
-        if (null == request.getHeader("Authorization")) {
-            return ResponseDto.fail("MEMBER_NOT_FOUND",
-                    "로그인이 필요합니다.");
-        }
-
-        Member member = validateMember(request);
-        if (null == member) {
-            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
-        }
-
-        Post post = postService.isPresentPost(postId);
-        if (null == post) {
-            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
-        }
-
-        Like like = isPresentLike(postId);
-        if (null == like) {
-            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 좋아요 id 입니다.");
-        }
-
-        if (like.validateMember(member)) {
-            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
-        }
-
-        likeRepository.delete(like);
-
-        return ResponseDto.success("Unlike success");
-    }
-
-    @Transactional
     public ResponseDto<?> unLikeByCommentId(Long commentId, HttpServletRequest request) {
 
         if (null == request.getHeader("Refresh-Token")) {
@@ -143,7 +141,74 @@ public class LikeService {
             return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
         }
 
-        Like like = isPresentLike(commentId);
+        Like like = isPresentLikeByCommentId(commentId);
+        if (null == like) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 좋아요 id 입니다.");
+        }
+
+        if (like.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+
+        likeRepository.delete(like);
+
+        return ResponseDto.success("Unlike success");
+    }
+
+    @Transactional
+    public ResponseDto<?> likeBySubCommentId(Long SubCommentId, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        SubComment subComment = subCommentService.isPresentSubComment(SubCommentId);
+        if (null == subComment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+        Like like = Like.builder()
+                .subComment(subComment)
+                .member(member)
+                .build();
+        likeRepository.save(like);
+        return ResponseDto.success("Like success");
+    }
+
+    @Transactional
+    public ResponseDto<?> unLikeBySubCommentId(Long SubCommentId, HttpServletRequest request) {
+
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        SubComment subComment = subCommentService.isPresentSubComment(SubCommentId);
+        if (null == subComment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+        Like like = isPresentLikeBySubCommentId(SubCommentId);
         if (null == like) {
             return ResponseDto.fail("NOT_FOUND", "존재하지 않는 좋아요 id 입니다.");
         }
@@ -158,8 +223,20 @@ public class LikeService {
     }
 
     @Transactional(readOnly = true)
-    public Like isPresentLike(Long id) {
-        Optional<Like> optionalLike = likeRepository.findById(id);
+    public Like isPresentLikeByPostId(Long postId) {
+        Optional<Like> optionalLike = likeRepository.findByPostId(postId);
+        return optionalLike.orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public Like isPresentLikeByCommentId(Long commentId) {
+        Optional<Like> optionalLike = likeRepository.findByCommentId(commentId);
+        return optionalLike.orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public Like isPresentLikeBySubCommentId(Long subCommentId) {
+        Optional<Like> optionalLike = likeRepository.findBySubCommentId(subCommentId);
         return optionalLike.orElse(null);
     }
 


### PR DESCRIPTION
- 각 Mapping 메소드명에 "Sub"추가
- Path : subcomment → sub-comment

2. SecurityConfiguration
- antMatchers : sub-comment 추가

3. Like 관련 SubComment 기능도 추가

4. Post, Comment, SubComment Delete 이슈 해결
- 각 @OneToMany 어노테이션에 MappedBy Attribute 추가